### PR TITLE
Allow last request to be aborted

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,7 @@
 	, "es3": true
 	, "immed": true
 	, "latedef": true
-	, "maxcomplexity": 14
+	, "maxcomplexity": 15
 	, "maxdepth": 3
 	, "maxerr": 1000000
     , "newcap": true


### PR DESCRIPTION
Currently Backbone.Siren does not save a reference to the jqXHR object from the request when it resolves a url. This pull request brings in a way (albeit an ugly way) to save the jqXHR object. This pull request also adds a method to abort the last request, which is only possible once the jqXHR object from the last request is being saved.
